### PR TITLE
Investigate deployment error on website

### DIFF
--- a/test/frontend/src/services/api.js
+++ b/test/frontend/src/services/api.js
@@ -1,4 +1,8 @@
-const BACKEND_URL = process.env.REACT_APP_BACKEND_URL;
+const DEFAULT_BACKEND_URL = "https://physio-backend-production-1a1b.up.railway.app";
+const BACKEND_URL =
+  (process.env.REACT_APP_BACKEND_URL && process.env.REACT_APP_BACKEND_URL.trim() !== ""
+    ? process.env.REACT_APP_BACKEND_URL
+    : DEFAULT_BACKEND_URL);
 const API = `${BACKEND_URL}/api`;
 
 // Generic API request handler

--- a/test/src/services/api.js
+++ b/test/src/services/api.js
@@ -1,4 +1,8 @@
-const BACKEND_URL = process.env.REACT_APP_BACKEND_URL || "https://physio-backend-production-1a1b.up.railway.app" || (typeof window !== 'undefined' ? window.location.origin : '');
+const DEFAULT_BACKEND_URL = "https://physio-backend-production-1a1b.up.railway.app";
+const BACKEND_URL =
+  (process.env.REACT_APP_BACKEND_URL && process.env.REACT_APP_BACKEND_URL.trim() !== ""
+    ? process.env.REACT_APP_BACKEND_URL
+    : DEFAULT_BACKEND_URL);
 const API = `${BACKEND_URL}/api`;
 
 // Generic API request handler


### PR DESCRIPTION
Configure API base URL for production to prevent `net::ERR_CONNECTION_REFUSED` errors on Vercel.

The Vercel deployment was making API calls to `http://127.0.0.1:5000`, resulting in connection refused errors, while local development worked correctly. This PR addresses the hardcoded `localhost` API endpoint.

---
<a href="https://cursor.com/background-agent?bcId=bc-bb36d565-db32-4cbd-86f2-1be73a7a403f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bb36d565-db32-4cbd-86f2-1be73a7a403f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

